### PR TITLE
Adding reveal grid spaces/neighbors

### DIFF
--- a/battle-sweep/package-lock.json
+++ b/battle-sweep/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "framer-motion": "^10.16.4",
         "react": "^18.2.0",
+        "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
         "rune-games-sdk": "^4.15.1"
       },
@@ -2634,6 +2635,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -3076,6 +3089,28 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.36.tgz",
+      "integrity": "sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/battle-sweep/package.json
+++ b/battle-sweep/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "framer-motion": "^10.16.4",
     "react": "^18.2.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
     "rune-games-sdk": "^4.15.1"
   },

--- a/battle-sweep/src/App.tsx
+++ b/battle-sweep/src/App.tsx
@@ -58,7 +58,7 @@ function App() {
       Rune.actions.revealReset();
       clearTimeout(timerRef.current || 0);
       timerRef.current = 0;
-    }, 2000);
+    }, 1500);
 
     Rune.actions.reveal({ row, col });
   };

--- a/battle-sweep/src/components/Board.css
+++ b/battle-sweep/src/components/Board.css
@@ -7,8 +7,9 @@
     background-color: #2C4EA4;
     font-family: "Courier New", monospace;
     font-weight: bold;
-
-    display: grid;
+    position: relative;
+    z-index: 1;
+    align-items: center;
 
     /*background-color: #f0f0f0; !* Light gray background color *!*/
     max-width: 350px; /* Adjust the max width as per your design */

--- a/battle-sweep/src/components/Board.tsx
+++ b/battle-sweep/src/components/Board.tsx
@@ -7,17 +7,23 @@ interface BoardProps {
   board: Array<Array<TileProp>>;
   display: boolean;
   onPress: (row: number, col: number) => void;
+  onLongPress: (row: number, col: number) => void;
 }
 
 //add game props from rune SDK
-function Board({ board, display, onPress }: BoardProps) {
+function Board({ board, display, onPress, onLongPress }: BoardProps) {
   if (display) {
     return (
       <>
         <div className="board">
           {board.map((row) =>
             row.map((tile, index) => (
-              <Tile key={index} onPress={onPress} {...tile} />
+              <Tile
+                key={index}
+                onPress={onPress}
+                onLongPress={onLongPress}
+                {...tile}
+              />
             ))
           )}
         </div>

--- a/battle-sweep/src/components/Tile.css
+++ b/battle-sweep/src/components/Tile.css
@@ -24,13 +24,50 @@
     height: 20px;
     padding: 2px;
 
-
     /*!*padding: 5px 6px; !* Increase the padding for a cleaner look *!*!*/
     /*border: none; !* Remove the border *!*/
     /*background-color: #ffffff; !* White background for tiles *!*/
     /*box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); !* Add a subtle shadow *!*/
     /*border-radius: 2px; !* Add some rounded corners to the tiles *!*/
 }
+
+.gradient-border {  
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    
+    &::after {
+      position: absolute;
+      content: "";
+      top: calc(-1 * 2px);
+      left: calc(-1 * 2px);
+      z-index: -1;
+      width: calc(100% + 2px * 2);
+      height: calc(100% + 2px * 2);
+      background: linear-gradient(
+        60deg,
+        hsl(224, 85%, 66%),
+        hsl(269, 85%, 66%),
+        hsl(314, 85%, 66%),
+        hsl(359, 85%, 66%),
+        hsl(44, 85%, 66%),
+        hsl(89, 85%, 66%),
+        hsl(134, 85%, 66%),
+        hsl(179, 85%, 66%)
+      );
+      background-size: 300% 300%;
+      background-position: 0 50%;
+      border-radius: calc(2 * 2px);
+      animation: moveGradient 4s alternate infinite;
+    }
+  }
+  
+  @keyframes moveGradient {
+    50% {
+      background-position: 100% 50%;
+    }
+  }
 
 .isBomb {
     /*background-color: #9D0814;*/

--- a/battle-sweep/src/components/Tile.tsx
+++ b/battle-sweep/src/components/Tile.tsx
@@ -1,4 +1,5 @@
 import "./Tile.css";
+import useLongPress from "../helper/UseLongPress";
 
 interface TileProps {
   row: number;
@@ -6,8 +7,10 @@ interface TileProps {
   isBomb: boolean;
   isFlipped: boolean;
   isMarked: boolean;
+  setReveal: boolean;
   value: number;
   onPress: (row: number, col: number) => void;
+  onLongPress: (row: number, col: number) => void;
 }
 
 function Tile({
@@ -16,12 +19,16 @@ function Tile({
   isBomb,
   isFlipped,
   isMarked,
+  setReveal,
   value,
   onPress,
+  onLongPress,
 }: TileProps) {
+  const LongPress = useLongPress(onPress, onLongPress, row, col);
+
   return (
     <div
-      onClick={() => onPress(row, col)}
+      {...LongPress}
       className={`tile ${
         isBomb && isFlipped
           ? "isBomb"
@@ -30,7 +37,8 @@ function Tile({
           : isMarked
           ? "isMarked"
           : "hidden"
-      }`}
+      } ${isBomb && isMarked && isFlipped && "gradient-border"}
+      ${setReveal && "gradient-border"}`}
     >
       {isBomb ? "" : value === 0 ? "" : value}
     </div>

--- a/battle-sweep/src/helper/BoardCreation.tsx
+++ b/battle-sweep/src/helper/BoardCreation.tsx
@@ -4,6 +4,7 @@ const emptyCell = {
   isBomb: false,
   isFlipped: true,
   isMarked: false,
+  setReveal: false,
   value: 0,
 };
 
@@ -103,6 +104,18 @@ export function getNeighbors(
   if (row + 1 < height && col - 1 >= 0) neighbors.push([row + 1, col - 1]); // DOWN-LEFT
 
   return neighbors;
+}
+
+export function resetReveal(board: Array<Array<TileProp>>) {
+  const refreshBoard = [];
+  for (let row = 0; row < board.length; row++) {
+    const newRow = [];
+    for (let col = 0; col < board[0].length; col++) {
+      newRow.push({ ...board[row][col], setReveal: false });
+    }
+    refreshBoard.push(newRow);
+  }
+  return refreshBoard;
 }
 
 export function toggleFlag(

--- a/battle-sweep/src/helper/useLongPress.tsx
+++ b/battle-sweep/src/helper/useLongPress.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useRef } from "react";
+import { isMobile } from "react-device-detect";
+
+export default function useLongPress(
+  onClick: (row: number, col: number) => void,
+  onLongPress: (row: number, col: number) => void,
+  row: number,
+  col: number,
+  ms = 500
+) {
+  // used to persist the timer state
+  // non zero values means the value has never been fired before
+  const timerRef = useRef<number>(0);
+
+  // clear timed callback
+  const endTimer = () => {
+    clearTimeout(timerRef.current || 0);
+    timerRef.current = 0;
+  };
+
+  // init timer
+  const onStartLongPress = useCallback(() => {
+    // stop any previously set timers
+    endTimer();
+
+    // set new timeout
+    timerRef.current = setTimeout(() => {
+      onLongPress(row, col);
+      endTimer();
+    }, ms);
+  }, [onLongPress, ms, row, col]);
+
+  // determine to end timer early and invoke the callback or do nothing
+  const onEndLongPress = useCallback(() => {
+    // run the callback fn the timer hasn't gone off yet (non zero)
+    if (timerRef.current) {
+      endTimer();
+      onClick(row, col);
+    }
+  }, [onClick, row, col]);
+
+  if (isMobile) {
+    return {
+      onTouchStart: onStartLongPress,
+      onTouchEnd: onEndLongPress,
+    };
+  } else {
+    return {
+      onMouseDown: onStartLongPress,
+      onMouseUp: onEndLongPress,
+      onMouseLeave: onEndLongPress,
+    };
+  }
+}
+
+/*
+Implementation:
+const [onStart, onEnd] = useLongPress(onPress, pressTest, row, col);
+<div>
+onTouchStart={onStart}
+onTouchEnd={onEnd}
+</div>
+
+Use:
+return [onStartLongPress, onEndLongPress, endTimer];
+
+OR
+Implementation:
+const LongPress = useLongPress(pressTest, onPress, row, col);
+<div> {...LongPress} </div>
+
+Use:
+  return {
+    onMouseDown: start,
+    onMouseUp: stop,
+    onMouseLeave: stop,
+    onTouchStart: start,
+    onTouchEnd: stop,
+  };
+}
+*/

--- a/battle-sweep/src/logic.ts
+++ b/battle-sweep/src/logic.ts
@@ -1,5 +1,5 @@
 import type { RuneClient, PlayerId } from "rune-games-sdk/multiplayer"
-import { createBoard, flipAll, insertBombs, toggleFlag, userInsertBomb, expand, flipCell } from "./helper/BoardCreation.tsx";
+import { createBoard, flipAll, insertBombs, toggleFlag, getNeighbors, userInsertBomb, expand, flipCell } from "./helper/BoardCreation.tsx";
 
 const boardWidth = 9;
 const boardHeight = 9;
@@ -33,6 +33,7 @@ type GameActions = {
   swap: () => void,
   flip: (args: { row: number ; col: number }) => void,
   flag: (args: { row: number ; col: number }) => void,
+  reveal: (args: { row: number ; col: number }) => void,
 }
 
 declare global {
@@ -50,6 +51,10 @@ const flipHandler = (game:GameState, oldBoard:Array<Array<TileProp>>, row:number
   } else {
     return flipCell(row, col, oldBoard)
   }}
+
+  const revealHandler = () => {
+    //
+  }
 
 Rune.initLogic({
   minPlayers: 1,
@@ -125,6 +130,30 @@ Rune.initLogic({
           game.playerState[player].board = newBoard
         }})
     },
+    reveal: ({row, col}, { game, allPlayerIds, playerId }) => {
+      const newBoard = board.slice();
+      const cell = newBoard[row][col];
+      const isFlipped = cell.isFlipped
+      if (!isFlipped) {/* return and show neighbor grids only */}
+      const value = cell.value;
+      const flags = [];
+      const bombs = [];
+
+      const neighbors = getNeighbors(row, col, newBoard);
+      for (const neighbor of neighbors) {
+          const [row, col] = neighbor;
+          if (newBoard[row][col].isBomb) {bombs.push([row, col])}
+          if (newBoard[row][col].isMarked) {flags.push([row, col])}
+      }
+
+      if (flags.length != value ) {{/* return and show neighbor grids only */}}
+
+      for (let coord = 0; row < flags.length; coord++) {
+          if (flags[coord] != bombs[coord]) {
+              // return false? flip the bomb cell using flip action
+          }
+      }
+    }
   }
   ,
   events: {


### PR DESCRIPTION
Added long press to reveal spaces logic

Gameflow:
1. Correctly flag bombs, and long press to reveal. Game continues, bombs found decrement* (* that logic doesn't exist yet)
<img width="294" alt="Flag" src="https://github.com/Joy-of-Coding/React_jam_2023_JoyofCoding/assets/93539953/f44ade80-09e3-4483-b276-d8df02d084d9">
<img width="290" alt="revealed" src="https://github.com/Joy-of-Coding/React_jam_2023_JoyofCoding/assets/93539953/1d1df6cc-d490-4590-8821-3c4012125706">


2. Incorrectly flag bombs, lose life or game over
<img width="295" alt="TestFlags" src="https://github.com/Joy-of-Coding/React_jam_2023_JoyofCoding/assets/93539953/27514982-5d74-4ab8-8285-b11aa269d267">
<img width="298" alt="GameOver" src="https://github.com/Joy-of-Coding/React_jam_2023_JoyofCoding/assets/93539953/eb1c3553-358b-4748-81dc-92ccbff36c8a">


3. Can also be used just to check all affected tiles in the number grid, aka possible bombs locations
![checkGrid](https://github.com/Joy-of-Coding/React_jam_2023_JoyofCoding/assets/93539953/561de8d3-6631-47fc-bc5b-def7eb131443)

